### PR TITLE
diff: call out znkr.io/diff/textdiff in znkr.io/diff

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -22,4 +22,8 @@
 //
 // Performance: Default complexity is O(N^1.5 log N) time and O(N) space. With [Minimal], time
 // complexity becomes O(ND) where N = len(x) + len(y) and D is the number of edits.
+//
+// Note: For a line-by-line diff of text, please see [znkr.io/diff/textdiff].
+//
+// [znkr.io/diff/textdiff]: https://pkg.go.dev/znkr.io/diff/textdiff
 package diff


### PR DESCRIPTION
As mentioned in https://github.com/twpayne/chezmoi/pull/4749#issuecomment-3478409461, it's easy to miss the textdiff package.