### PR TITLE
textdiff: implement support for colored output

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -44,9 +44,18 @@ type Config struct {
 	// If set, textdiff will apply ident heuristics.
 	IndentHeuristic bool
 
+	// If not nil, textdiff.Unify will use this to color the output.
+	Colors *ColorConfig
+
 	// If set, internal/myers will always use the anchoring heuristic. This configuration is not
 	// exposed via an option API, it's main use is for testing.
 	ForceAnchoringHeuristic bool
+}
+
+type ColorConfig struct {
+	Reset                 string
+	HunkHeader            string
+	Match, Delete, Insert string
 }
 
 // Default is the default configuration.
@@ -66,6 +75,7 @@ const (
 	Minimal
 	Fast
 	IndentHeuristic
+	TerminalColors
 )
 
 // Option is the mechanism used to expose the configuration to users.
@@ -96,6 +106,8 @@ func printFlag(flag Flag) string {
 		return "diff.Fast"
 	case IndentHeuristic:
 		return "textdiff.IndentHeuristic"
+	case TerminalColors:
+		return "textdiff.TerminalColors"
 	default:
 		panic("never reached")
 	}

--- a/textdiff/color/color.go
+++ b/textdiff/color/color.go
@@ -1,0 +1,69 @@
+// Package color provides configuration for coloring for unified diffs using ANSI escape sequences.
+//
+// Specifying colors uses [Select Graphic Rendition parameters]. For example the code below,
+// presents the header in bold yellow:
+//
+//	HunkHeader(1, 33)
+//
+// This is equivalent to the following raw ANSI sequence: \033[1;33m.
+//
+// It's the responsibility of the caller to ensure that the parameters are correct and supported
+// by the underlying terminal.
+//
+// [Select Graphic Rendition parameters]: https://en.wikipedia.org/wiki/ANSI_escape_code#SGR
+package color
+
+import (
+	"fmt"
+	"strings"
+
+	"znkr.io/diff/internal/config"
+)
+
+// A Option makes it possible to configure custom colors in [TerminalColors].
+type Option func(*config.ColorConfig)
+
+// HunkHeaders colors hunk headers, the "@@ ... @@" part of the unified diff.
+func HunkHeaders(params ...int) Option {
+	code := format(params)
+	return func(cc *config.ColorConfig) {
+		cc.HunkHeader = code
+	}
+}
+
+// Matches colors matching lines.
+func Matches(params ...int) Option {
+	code := format(params)
+	return func(cc *config.ColorConfig) {
+		cc.Match = code
+	}
+}
+
+// Deletes colors deleted lines.
+func Deletes(params ...int) Option {
+	code := format(params)
+	return func(cc *config.ColorConfig) {
+		cc.Delete = code
+	}
+}
+
+// Inserts colors deleted lines.
+func Inserts(params ...int) Option {
+	code := format(params)
+	return func(cc *config.ColorConfig) {
+		cc.Insert = code
+	}
+}
+
+func format(params []int) string {
+	var sb strings.Builder
+	sb.WriteString("\033[")
+	for i, v := range params {
+		if i > 0 {
+			sb.WriteRune(';')
+		}
+		fmt.Fprint(&sb, v)
+	}
+	sb.WriteRune('m')
+	return sb.String()
+}

--- a/textdiff/options.go
+++ b/textdiff/options.go
@@ -15,9 +15,17 @@
 package textdiff
 
 import (
-	"znkr.io/diff"
 	"znkr.io/diff/internal/config"
+	"znkr.io/diff/textdiff/color"
 )
+
+// Option configures the behavior of comparison functions.
+//
+// Note: The [options defined in the diff package] work for most functions in this package too. See
+// the description of the individual functions for a list of supported options.
+//
+// [options defined in the diff package]: https://pkg.go.dev/znkr.io/diff#Option
+type Option = config.Option
 
 // IndentHeuristic applies a heuristic to make diffs easier to read by improving the placement of
 // edit boundaries.
@@ -25,9 +33,36 @@ import (
 // This implements a heuristic that shifts edit boundaries to align with indentation patterns,
 // making the resulting diff more readable for humans. The heuristic is particularly effective with
 // code and structured text.
-func IndentHeuristic() diff.Option {
+func IndentHeuristic() Option {
 	return func(cfg *config.Config) config.Flag {
 		cfg.IndentHeuristic = true
 		return config.IndentHeuristic
+	}
+}
+
+// TerminalColors uses ANSI escape codes to color the output of [Unified].
+//
+// By default, the colors try to emulate git's color scheme, but the colors can be overridden using
+// [color.Option].
+//
+// Note: Using TerminalColors will output ANSI escape quotes unconditionally. It's the callers
+// responsibility to make sure it's only used in contexts that support ANSI escape sequences (e.g.
+// by guarding the use of this option with [github.com/mattn/go-isatty]).
+//
+// [github.com/mattn/go-isatty]: https://pkg.go.dev/github.com/mattn/go-isatty
+func TerminalColors(opts ...color.Option) Option {
+	return func(c *config.Config) config.Flag {
+		colors := config.ColorConfig{
+			Reset:      "\033[m",
+			HunkHeader: "\033[36m", // Cyan
+			Match:      "",         // Normal
+			Delete:     "\033[31m", // Red
+			Insert:     "\033[32m", // Green
+		}
+		for _, opt := range opts {
+			opt(&colors)
+		}
+		c.Colors = &colors
+		return config.TerminalColors
 	}
 }


### PR DESCRIPTION
Coloring is only possible for unified diffs

Fixes #14 